### PR TITLE
toTexture don't forceClear the renderer

### DIFF
--- a/Wagner.js
+++ b/Wagner.js
@@ -104,7 +104,7 @@ WAGNER.Composer.prototype.toTexture = function( t ) {
 	if( this.copyPass.isLoaded() ) {
 		this.quad.material = this.copyPass.shader;
 		this.quad.material.uniforms.tInput.value = this.read;
-		this.renderer.render( this.scene, this.camera, t, true );
+		this.renderer.render( this.scene, this.camera, t, false );
 	}
 
 };


### PR DESCRIPTION
I don't think Composer.toTexture should forceClear the renderer.

It can be a source of bug and still can be call manually when needed.