### PR TITLE
fix coefficients for detecting brightness

### DIFF
--- a/fragment-shaders/crossfade-fs.glsl
+++ b/fragment-shaders/crossfade-fs.glsl
@@ -12,7 +12,7 @@ void main( void ) {
 	float range = .2;
 	vec4 from = texture2D( tInput, vUv );
 	vec4 to = texture2D( tInput2, vUv );
-	vec3 luma = vec3( .299, 0.587, 0.114 );
+	vec3 luma = vec3( .213, .715, .072 );
 	float v = clamp( dot( luma, texture2D( tFadeMap, vUv ).rgb ), 0., 1. - range );
 
 	float threshold = 0.1;

--- a/fragment-shaders/fxaa-fs.glsl
+++ b/fragment-shaders/fxaa-fs.glsl
@@ -16,7 +16,7 @@ void main() {
     vec3 rgbSE = texture2D( tInput, ( vUv.xy + vec2( 1.0, 1.0 ) * res ) ).xyz;
     vec4 rgbaM  = texture2D( tInput,  vUv.xy  * res );
     vec3 rgbM  = rgbaM.xyz;
-    vec3 luma = vec3( 0.299, 0.587, 0.114 );
+    vec3 luma = vec3( .213, .715, .072 );
 
     float lumaNW = dot( rgbNW, luma );
     float lumaNE = dot( rgbNE, luma );

--- a/fragment-shaders/fxaa2-fs.glsl
+++ b/fragment-shaders/fxaa2-fs.glsl
@@ -27,7 +27,7 @@ void main() {
   vec3 rgbSE = texture2D(tInput, vertTexcoord.xy + (vec2(+1.0, +1.0) * texcoordOffset)).xyz;
   vec3 rgbM  = texture2D(tInput, vertTexcoord.xy).xyz;
 	
-  vec3 luma = vec3(0.299, 0.587, 0.114);
+  vec3 luma = vec3( .213, .715, .072 );
   float lumaNW = dot(rgbNW, luma);
   float lumaNE = dot(rgbNE, luma);
   float lumaSW = dot(rgbSW, luma);

--- a/fragment-shaders/grayscale-fs.glsl
+++ b/fragment-shaders/grayscale-fs.glsl
@@ -4,7 +4,7 @@ uniform vec2 resolution;
 
 void main() {
 
-	vec3 luma = vec3( .299, 0.587, 0.114 );
+	vec3 luma = vec3( .213, .715, .072 );
 	vec4 color = texture2D( tInput, vUv );
 	gl_FragColor = vec4( vec3( dot( color.rgb, luma ) ), color.a );
 

--- a/fragment-shaders/guided-directional-blur-fs.glsl
+++ b/fragment-shaders/guided-directional-blur-fs.glsl
@@ -7,7 +7,7 @@ float random(vec3 scale,float seed){return fract(sin(dot(gl_FragCoord.xyz+seed,s
 
 float sampleBias( vec2 uv ) {
 	//return texture2D( tBias, uv ).r;
-	vec3 luma = vec3( .299, 0.587, 0.114 );
+	vec3 luma = vec3( .213, .715, .072 );
 	return dot( texture2D( tBias, uv ).rgb, luma );
 }
 

--- a/fragment-shaders/halftone-fs.glsl
+++ b/fragment-shaders/halftone-fs.glsl
@@ -19,7 +19,7 @@ void main(void) {
 	p.x -= dx;
 	p.y -= dy;
 	vec3 col = texture2D(tInput, p).rgb;
-	vec3 luma = vec3( .299, 0.587, 0.114 );
+	vec3 luma = vec3( .213, .715, .072 );
 	float bright = dot( col.rgb, luma );
 	
 	float dist = sqrt(dx*dx + dy*dy);

--- a/fragment-shaders/halftone2-fs.glsl
+++ b/fragment-shaders/halftone2-fs.glsl
@@ -31,7 +31,7 @@ void main(void) {
   vec2 d = vec2( 1. / amount ) * vec2( 1., ar );
   vec2 tUv = floor( vUv / d ) * d;
   vec3 dotColorCalculation = texture2D( tInput, tUv ).rgb;
-  vec3 luma = vec3( .299, 0.587, 0.114 );
+  vec3 luma = vec3( .213, .715, .072 );
   vec3 gradientColor = dotColorCalculation ;//texture2D( tInput, vUv ).rgb;
   float radius = sqrt( dot( dotColorCalculation, luma ) );
 

--- a/fragment-shaders/ssao-simple-fs.glsl
+++ b/fragment-shaders/ssao-simple-fs.glsl
@@ -176,7 +176,7 @@ void main(void)
   /*
   vec3 color = texture2D(bgl_RenderedTexture,texCoord).rgb;
 
-  vec3 lumcoeff = vec3(0.299,0.587,0.114);
+  vec3 lumcoeff = vec3(0.213, 0.715, 0.072);
   float lum = dot(color.rgb, lumcoeff);
   vec3 luminance = vec3(lum, lum, lum);
 


### PR DESCRIPTION
The formula using to calculate relative luminance (or brightness):
Y = 0.299 R + 0.587 G + 0.114 

But it is correct in NTSC (1953) color space only. This formula is deprecated and legacy.
Actual color space sRGB significantly different: [chromacity diagram](https://habrastorage.org/getpro/habr/post_images/ece/82d/de9/ece82dde9aefff243777d61281a721da.jpg).

Correct formula is:
Y = 0.2126 R + 0.7152 G + 0.0722 B

[The proof of numbers](https://habrastorage.org/getpro/habr/post_images/2ab/69d/084/2ab69d084f9a597e032624bcd74d57a7.png)
Source — [Bruce Lindbloom site](http://www.brucelindbloom.com/index.html?WorkingSpaceInfo.html)
See also — [Charles Poynton Color FAQ](http://www.poynton.com/notes/colour_and_gamma/ColorFAQ.html#RTFToC9)

A lot of work or refactoring is not required. We can simply replace this coefficients.
